### PR TITLE
PMIx_Get_all / PMIx_Get_all_nb

### DIFF
--- a/RFC0016.md
+++ b/RFC0016.md
@@ -1,0 +1,63 @@
+# RFCnnnn
+The RFC number will be provided upon submission.
+
+## Title
+PMIx_Get_all / PMIx_Get_all_nb
+
+## Abstract
+The PMIx_Get / PMIx_Get_nb interface allows the user to access one key/value pair. If an application wants to get a set of keys they must make multiple calls into PMIx_Get. This API would allow them to make one call to get all of they keys at once. This allows the PMIx library to optimize how it searches for those keys.
+
+## Labels
+[EXTENSION] [CLIENT-API]
+
+## Action
+
+
+## Copyright Notice
+Copyright (c) 2017      IBM Corporation.  All rights reserved.
+
+This document is subject to all provisions relating to code contributions to the PMIx community as defined in the community's [LICENSE](https://github.com/pmix/RFCs/tree/master/LICENSE) file. Code Components extracted from this document must include the License text as described in that file.
+
+## Description
+Add a new pair of interfaces to get a set of keys from the library.
+
+```
+pmix_status_t PMIx_Get_all(const pmix_proc_t **procs, const char *keys[],
+                           const pmix_info_t info[], size_t ninfo,
+                           size_t count, pmix_status_t *statuses,
+                           pmix_value_t ***vals);
+ - procs    : array of size 'count'
+ - keys     : array of size 'count'
+ - vals     : array of size 'count'
+ - statuses : array of size 'count'
+
+pmix_status_t PMIx_Get_all_nb(const pmix_proc_t **procs, const char *keys[],
+                              const pmix_info_t info[], size_t ninfo,
+                              size_t count,
+                              pmix_value_cbfunc_t *cbfuncs, void **cbdata);
+ - procs    : array of size 'count'
+ - keys     : array of size 'count'
+ - cbfuncs  : array of size 'count'
+ - cbdata   : array of size 'count'
+
+One new error code will be added:
+ - PMIX_ERR_IN_STATUS : One or more keys are marked as error in 'statuses'
+```
+
+The PMIx_Get_all / PMIx_Get_all_nb calls have the same semantics as the PMIx_Get / PMIx_Get_nb calls with the following additional requirements:
+ - There is a index correlation between the various arrays. For example, index 'i' in procs corresponds to index 'i' in keys.
+ - PMIx_Get_all has the same effect as calling:
+   for(i = 0; i < count; ++i)
+      statuses[i] = PMIx_Get(procs[i], keys[i], info, ninfo, vals[i]);
+ - PMIx_Get_all will complete once all keys have been processed.
+ - PMIx_Get_all will return PMIX_SUCCESS if all keys were found and values filled in, and PMIX_ERR_IN_STATUS if one or more of the keys is marked in error. The statuses array will be updated at each location with either PMIX_SUCCESS or the error corresponding to the key at the same index.
+ - PMIx_Get_all will apply the info and ninfo arguments to each of the requests.
+ - PMIx_Get_all_nb will call the associated cbfunc once the key at the same index has been processed. These may not occur in a linear order.
+
+## Protoype Implementation
+TBD
+
+## Author(s)
+Josh Hursey
+IBM
+Github: jjhursey


### PR DESCRIPTION
An interface to get a set of key/value pairs from PMIx in a single call. This allows the PMIx library to optimize the handling of these requests more efficiently internally by, for example, locking a single time before acquiring all keys instead of locking for each key.